### PR TITLE
Rework preprocess and convert to use a DataFrame Structure

### DIFF
--- a/pydicer/convert/data.py
+++ b/pydicer/convert/data.py
@@ -1,9 +1,9 @@
 import logging
-import hashlib
 from pathlib import Path
 import SimpleITK as sitk
 
 from pydicer.convert.rtstruct import convert_rtstruct, write_nrrd_from_mask_directory
+from pydicer.utils import hash_uid
 
 from pydicer.constants import (
     RT_STRUCTURE_STORAGE_UID,
@@ -18,11 +18,14 @@ class ConvertData:
     Class that facilitates the conversion of the data into its intended final type
 
     Args:
-        - preprocess_dic: the dictionary that contains the preprocessed data information
+        - :
+        df_preprocess (pd.DataFrame): the DataFrame which was produced by PreprocessData
+        output_directory (str|pathlib.Path, optional): Directory in which to store converted data.
+            Defaults to ".".
     """
 
-    def __init__(self, preprocess_dic, output_directory="."):
-        self.preprocess_dic = preprocess_dic
+    def __init__(self, df_preprocess, output_directory="."):
+        self.df_preprocess = df_preprocess
         self.output_directory = Path(output_directory)
 
     def convert(self):
@@ -30,62 +33,95 @@ class ConvertData:
         Function to convert the data into its intended form (eg. images into Nifti)
         """
 
-        for series_uid, file_dic in self.preprocess_dic.items():
+        for series_uid, df_files in self.df_preprocess.groupby("series_uid"):
 
-            hash_sha = hashlib.sha256()
-            hash_sha.update(file_dic["study_id"].encode("UTF-8"))
-            study_id_hash = hash_sha.hexdigest()[:6]
+            # Grab the patied_id, study_uid, sop_class_uid and modality (should be the same for all
+            # files in series)
+            patient_id = df_files.patient_id.unique()[0]
+            study_uid = df_files.study_uid.unique()[0]
+            sop_class_uid = df_files.sop_class_uid.unique()[0]
+            modality = df_files.sop_class_uid.unique()[0]
 
-            hash_sha = hashlib.sha256()
-            hash_sha.update(series_uid.encode("UTF-8"))
-            series_uid_hash = hash_sha.hexdigest()[:6]
+            # Prepare some hashes of these UIDs to use for directory/file output paths
+            study_id_hash = hash_uid(study_uid)
+            series_uid_hash = hash_uid(series_uid)
 
-            if file_dic["sop_class_uid"] == CT_IMAGE_STORAGE_UID:
-                series_files = [str(x["path"]) for x in file_dic["files"]]
-                series = sitk.ReadImage(series_files)
+            try:
 
-                output_file = self.output_directory.joinpath(
-                    file_dic["patient_id"], study_id_hash, "images", f"CT_{series_uid_hash}.nii.gz"
-                )
-                output_file.parent.mkdir(exist_ok=True, parents=True)
-                sitk.WriteImage(series, str(output_file))
-                logger.debug("Writing CT Image Series to: %s", output_file)
+                if sop_class_uid == CT_IMAGE_STORAGE_UID:
+                    series_files = df_files.file_path.tolist()
+                    series_files = [str(f) for f in series_files]
+                    series = sitk.ReadImage(series_files)
 
-            elif file_dic["sop_class_uid"] == RT_STRUCTURE_STORAGE_UID:
+                    output_file = self.output_directory.joinpath(
+                        patient_id, study_id_hash, "images", f"CT_{series_uid_hash}.nii.gz"
+                    )
+                    output_file.parent.mkdir(exist_ok=True, parents=True)
+                    sitk.WriteImage(series, str(output_file))
+                    logger.debug("Writing CT Image Series to: %s", output_file)
 
-                # Get the linked image
-                linked_uid = file_dic["linked_series_uid"]["referenced_series_uid"]
-                linked_dicom_dict = self.preprocess_dic[linked_uid]
+                elif sop_class_uid == RT_STRUCTURE_STORAGE_UID:
 
-                hash_sha = hashlib.sha256()
-                hash_sha.update(linked_uid.encode("UTF-8"))
-                linked_uid_hash = hash_sha.hexdigest()[:6]
+                    # Should only be one file per RTSTRUCT series
+                    if not len(df_files) == 1:
+                        ValueError("More than one RTSTRUCT with the same SeriesInstanceUID")
 
-                output_dir = self.output_directory.joinpath(
-                    file_dic["patient_id"],
-                    study_id_hash,
-                    "structures",
-                    f"{series_uid_hash}_{linked_uid_hash}",
-                )
-                output_dir.mkdir(exist_ok=True, parents=True)
+                    rt_struct_file = df_files.iloc[0]
 
-                img_file_list = [str(f["path"]) for f in linked_dicom_dict["files"]]
+                    # Get the linked image
+                    # TODO Link via alternative method if referenced_series_uid is not available
+                    linked_uid = rt_struct_file.referenced_series_uid
+                    df_linked_series = self.df_preprocess[
+                        self.df_preprocess.series_uid == rt_struct_file.referenced_series_uid
+                    ]
 
-                convert_rtstruct(
-                    img_file_list,
-                    file_dic["files"][0],
-                    prefix="",
-                    output_dir=output_dir,
-                    output_img=None,
-                    spacing=None,
-                )
+                    # Check that the linked series is available
+                    # TODO handle rendering the masks even if we don't have an image series it's
+                    # linked to
+                    if len(df_linked_series) == 0:
+                        raise ValueError("Series Referenced by RTSTRUCT not found")
 
-                # TODO Make generation of NRRD file optional, as well as the colormap configurable
-                nrrd_file = self.output_directory.joinpath(
-                    file_dic["patient_id"],
-                    study_id_hash,
-                    "structures",
-                    f"{series_uid_hash}_{linked_uid_hash}.nrrd",
-                )
+                    linked_uid_hash = hash_uid(linked_uid)
 
-                write_nrrd_from_mask_directory(output_dir, nrrd_file)
+                    output_dir = self.output_directory.joinpath(
+                        patient_id,
+                        study_id_hash,
+                        "structures",
+                        f"{series_uid_hash}_{linked_uid_hash}",
+                    )
+                    output_dir.mkdir(exist_ok=True, parents=True)
+
+                    img_file_list = df_linked_series.file_path.tolist()
+                    img_file_list = [str(f) for f in img_file_list]
+
+                    convert_rtstruct(
+                        img_file_list,
+                        rt_struct_file.file_path,
+                        prefix="",
+                        output_dir=output_dir,
+                        output_img=None,
+                        spacing=None,
+                    )
+
+                    # TODO Make generation of NRRD file optional (especially because these files
+                    # are quite large), as well as the colormap configurable
+                    nrrd_file = self.output_directory.joinpath(
+                        patient_id,
+                        study_id_hash,
+                        "structures",
+                        f"{series_uid_hash}_{linked_uid_hash}.nrrd",
+                    )
+
+                    write_nrrd_from_mask_directory(output_dir, nrrd_file)
+
+                else:
+                    raise NotImplementedError(
+                        "Unable to convert Series with SOP Class UID: {sop_class_uid} / "
+                        f"Modality: {modality}"
+                    )
+
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error(e)
+                logger.error("Unable to convert series with UID")
+
+                # TODO send to quarantine

--- a/pydicer/preprocess/data.py
+++ b/pydicer/preprocess/data.py
@@ -1,5 +1,7 @@
 import logging
 
+import pandas as pd
+
 import pydicom
 import numpy as np
 
@@ -29,44 +31,55 @@ class PreprocessData:
         """
         Function to preprocess information regarding the data located in an Input working directory
 
-        Returns: res_dict (dict): keys are series UIDs. For each series; we have 5 lower keys:
-            - the hashed patient ID
-            - the hashed study UID
-            - a list of dicts that has 2 keys (path to file, slice location)
-            - the series modality
-            - the series UID that it is linked to
+        Returns: res_dict (pd.DataFrame): containing a row for each DICOM file that was
+           preprocessed, with the following columns:
+            - patient_id: PatientID field from the DICOM header
+            - study_uid: StudyInstanceUID field from the DICOM header
+            - series_uid: SeriesInstanceUID field from the DICOM header
+            - modality: Modailty field from the DICOM header
+            - sop_class_uid: SOPClassUID field from the DICOM header
+            - for_uid: FrameOfReferenceUID field from the DICOM header
+            - file_path: The path to the file (as a pathlib.Path object)
+            - slice_location: The real-world location of the slice (used for imaging modalities)
+            - referenced_series_uid: The SeriesUID referenced by this DICOM file (used for RTSTRUCT
+              and RTDOSE)
+            - referenced_for_uid: The ReferencedFrameOfReferenceUID referenced by this DICOM file
 
-        Ex:
-            {
-                "series_uid": {
-                    "patient_id": "",
-                    "study_id": "",
-                    "files": [],
-                    "modality": "",
-                    "linked_series_uid": {}
-                }
-            }
         """
-        res_dict = {}
+        df = pd.DataFrame(
+            columns=[
+                "patient_id",
+                "study_uid",
+                "series_uid",
+                "modality",
+                "sop_class_uid",
+                "for_uid",
+                "file_path",
+                "slice_location",
+                "referenced_series_uid",
+                "referenced_for_uid",
+            ]
+        )
         files = self.working_directory.glob("**/*.dcm")
 
         for file in files:
             ds = pydicom.read_file(file, force=True)
 
-            linked_series_uid = {}
-
             try:
 
                 dicom_type_uid = ds.SOPClassUID
 
-                if ds.SeriesInstanceUID not in res_dict:
-                    res_dict[ds.SeriesInstanceUID] = {
-                        "patient_id": ds.PatientID,
-                        "study_id": ds.StudyInstanceUID,
-                        "files": [],
-                        "modality": ds.Modality,
-                        "sop_class_uid": dicom_type_uid,
-                    }
+                res_dict = {
+                    "patient_id": ds.PatientID,
+                    "study_uid": ds.StudyInstanceUID,
+                    "series_uid": ds.SeriesInstanceUID,
+                    "modality": ds.Modality,
+                    "sop_class_uid": dicom_type_uid,
+                    "file_path": str(file),
+                }
+
+                if "FrameOfReferenceUID" in ds:
+                    res_dict["for_uid"] = ds.FrameOfReferenceUID
 
                 if dicom_type_uid == RT_STRUCTURE_STORAGE_UID:
 
@@ -77,19 +90,20 @@ class PreprocessData:
                             .RTReferencedSeriesSequence[0]
                             .SeriesInstanceUID
                         )
-                        linked_series_uid["referenced_series_uid"] = referenced_series_uid
+                        res_dict["referenced_series_uid"] = referenced_series_uid
                     except AttributeError:
+                        logger.warning("Unable to determine Reference Series UID")
+
+                    try:
                         # Check other tags for a linked DICOM
                         # e.g. ds.ReferencedFrameOfReferenceSequence[0].FrameOfReferenceUID
                         # Potentially, we should check each referenced
                         referenced_frame_of_reference_uid = ds.ReferencedFrameOfReferenceSequence[
                             0
                         ].FrameOfReferenceUID
-                        linked_series_uid[
-                            "referenced_frame_of_reference_uid"
-                        ] = referenced_frame_of_reference_uid
-
-                    res_dict[ds.SeriesInstanceUID]["files"].append(file)
+                        res_dict["referenced_for_uid"] = referenced_frame_of_reference_uid
+                    except AttributeError:
+                        logger.warning("Unable to determine Referenced Frame of Reference UID")
 
                 elif dicom_type_uid == CT_IMAGE_STORAGE_UID:
 
@@ -100,32 +114,23 @@ class PreprocessData:
 
                     slice_location = (image_position * image_plane_normal)[2]
 
-                    temp_dict = {"path": file, "slice_location": slice_location}
-
-                    res_dict[ds.SeriesInstanceUID]["files"].append(temp_dict)
+                    res_dict["slice_location"] = slice_location
 
                 else:
                     raise ValueError("Could not determine DICOM type.")
+
+                # Add as a row to the DataFrame
+                df = df.append(res_dict, ignore_index=True)
 
             except Exception as e:  # pylint: disable=broad-except
                 # Broad except ok here, since we will put these file into a
                 # quarantine location for further inspection.
                 logger.error("Error parsing file %s: %s", file, e)
 
-            # Include any linked DICOM series
-            # This is a dictionary holding potential matching series
-            res_dict[ds.SeriesInstanceUID]["linked_series_uid"] = linked_series_uid
+                # TODO Send to quarantine
 
-        # Sort the files for each series by the slice_location (if available)
-        for _, value in res_dict.items():
+        # Sort the the DataFrame by the patient then series uid and the slice location, ensuring
+        # that the slices are ordered correctly
+        df = df.sort_values(["patient_id", "series_uid", "slice_location"])
 
-            if len(value["files"]) == 0:
-                continue
-
-            if not isinstance(value["files"][0], dict):
-                continue
-
-            if "slice_location" in value["files"][0]:
-                value["files"].sort(key=lambda x: x["slice_location"])
-
-        return res_dict
+        return df

--- a/pydicer/utils.py
+++ b/pydicer/utils.py
@@ -1,0 +1,17 @@
+import hashlib
+
+
+def hash_uid(uid, truncate=6):
+    """Hash a UID and truncate it
+
+    Args:
+        uid (str): The UID to hash
+        truncate (int, optional): The number of the leading characters to keep. Defaults to 6.
+
+    Returns:
+        str: The hashed and trucated UID
+    """
+
+    hash_sha = hashlib.sha256()
+    hash_sha.update(uid.encode("UTF-8"))
+    return hash_sha.hexdigest()[:truncate]


### PR DESCRIPTION
Hello @rnfinnegan @dalmouiee @ShuchaoPangUNSW @ayhaidar 

As discussed in our last meeting (#40), here is some code to utilise a Pandas DataFrame as the object to pass between the preprocess module and the convert module. The change was pretty smooth. I quite like having this type of data object, since you can save it off for debugging etc really nicely. I imaging that down the road we can add more columns to it as needed.

I'd be very interested to hear your thoughts. Please add a code review (even if just to practice using GitHub's code reviews :))