### PR TITLE
Initial CLI design

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -159,7 +159,8 @@ disable=print-statement,
         too-many-arguments,
         too-many-branches,
         too-many-locals,
-        too-many-statements
+        too-many-statements,
+        keyword-arg-before-vararg
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pydicer/cli/contants.py
+++ b/pydicer/cli/contants.py
@@ -1,0 +1,41 @@
+def get_sub_help_mesg(input_commands):
+    # pylint: disable=missing-function-docstring
+    help_mesg = f"""Subcommand of the following: {input_commands}
+
+
+    test WORKING_DIRECTORY_PATH
+        - WORKING_DIRECTORY_PATH (str, optional): The working directory in which to
+    store the data fetched. Defaults to a temp directory.
+    
+        Example usage:
+            python -m pydicer.cli.run input --type test cli_test
+    
+
+    pacs HOST_IP PORT AE_TITLE WORKING_DIRECTORY_PATH MODALITY [PATIENT_IDs]
+        - HOST_IP (str, optional): The IP address of host name of DICOM PACS. Defaults to 
+    'www.dicomserver.co.uk'.
+        - PORT (int, optional): The port to use to communicate on. Defaults to 11112.
+        - AE_TITLE (str, optional): AE Title to provide the DICOM service. Defaults to 
+    None.
+        - WORKING_DIRECTORY_PATH (str, optional): The working directory in which to
+    store the data fetched. Defaults to a temp directory.
+        - MODALITY (str, optional): The modality to retrieve DICOMs for. Defaults 
+    to 'GM'.
+        - PATIENT_IDs (str, required): a string-list of patient IDs (IDs seperated by spaces)
+     to retrieve the DICOMs for.
+    
+        Example usage:
+            python -m pydicer.cli.run input --type pacs www.dicomserver.co.uk 11112 DCMQUERY 
+    cli_test GM PAT004 PAT005
+    
+    
+    web DATA_URL WORKING_DIRECTORY_PATH
+       - DATA_URL (str): URL of the dataset to be downloaded from the internet
+       - WORKING_DIRECTORY_PATH (str, optional): The working directory in which to 
+    store the data fetched. Defaults to a temp directory.
+    
+        Example usage:
+            python -m pydicer.cli.run input --type web 
+https://zenodo.org/record/5276878/files/HNSCC.zip cli_test"""
+
+    return help_mesg

--- a/pydicer/cli/contants.py
+++ b/pydicer/cli/contants.py
@@ -7,45 +7,45 @@ def get_sub_help_mesg(input_commands, command):
 
         Runs the command using the default test data. Check pydicer.input.test for more info
 
-            - WORKING_DIRECTORY_PATH (str): The working directory in which to
+            - WORKING_DIRECTORY_PATH: The working directory in which to
                 store the data fetched. Defaults to a temp directory.
         
             Example usage:
-                python -m pydicer.cli.run input --type test cli_test
+                python -m pydicer.cli.run input|pipeline --type test cli_test
 
         pacs WORKING_DIRECTORY_PATH HOST_IP PORT AE_TITLE MODALITY [PATIENT_IDs]
 
         Runs the command by querying a DIOCM PACS server and storing the data on locally on the
         filesystem
 
-            - WORKING_DIRECTORY_PATH (str): The working directory in which to
+            - WORKING_DIRECTORY_PATH: The working directory in which to
                 store the data fetched. Defaults to a temp directory.
-            - HOST_IP (str, optional): The IP address of host name of DICOM PACS. Defaults to 
+            - HOST_IP (optional): The IP address of host name of DICOM PACS. Defaults to 
                 'www.dicomserver.co.uk'.
-            - PORT (int, optional): The port to use to communicate on. Defaults to 11112.
-            - AE_TITLE (str, optional): AE Title to provide the DICOM service. Defaults to 
+            - PORT (optional): The port to use to communicate on. Defaults to 11112.
+            - AE_TITLE (optional): AE Title to provide the DICOM service. Defaults to 
             None.
-            - MODALITY (str, optional): The modality to retrieve DICOMs for. Defaults 
+            - MODALITY (optional): The modality to retrieve DICOMs for. Defaults 
                 to 'GM'.
-            - PATIENT_IDs (str, required): a string-list of patient IDs (IDs seperated by spaces)
+            - PATIENT_IDs (required): a string-list of patient IDs (IDs seperated by spaces)
                 to retrieve the DICOMs for.
         
             Example usage:
-                python -m pydicer.cli.run input --type pacs www.dicomserver.co.uk 11112 DCMQUERY 
-                    cli_test GM PAT004 PAT005
+                python -m pydicer.cli.run input|pipeline --type pacs www.dicomserver.co.uk 11112
+                    DCMQUERY cli_test GM PAT004 PAT005
         
         
         web WORKING_DIRECTORY_PATH DATA_URL
 
-        Runs the command by downloading data from a provided URL and sotring it locally on the
+        Runs the command by downloading data from a provided URL and storing it locally on the
         filesystem
 
-        - WORKING_DIRECTORY_PATH (str): The working directory in which to 
+        - WORKING_DIRECTORY_PATH: The working directory in which to 
                 store the data fetched. Defaults to a temp directory.
-        - DATA_URL (str): URL of the dataset to be downloaded from the internet
+        - DATA_URL: URL of the dataset to be downloaded from the internet
         
             Example usage:
-                python -m pydicer.cli.run input --type web 
+                python -m pydicer.cli.run input|pipeline --type web 
                 https://zenodo.org/record/5276878/files/HNSCC.zip cli_test
         """
     if command == "pipeline":
@@ -53,18 +53,24 @@ def get_sub_help_mesg(input_commands, command):
 
         filesystem WORKING_DIRECTORY_PATH
 
-        Runs the pipeline using a filesystem working directory which contains DICOM images
+        Runs the pipeline using a filesystem working directory which contains DICOM images as input
 
-            - WORKING_DIRECTORY_PATH (str): The working directory in which to
+            - WORKING_DIRECTORY_PATH: The working directory in which to
                 store the data fetched. Defaults to a temp directory.
         
             Example usage:
-                python -m pydicer.cli.run filesystem --type test cli_test
+                python -m pydicer.cli.run pipeline --type filesystem cli_test
         
 
         e2e
 
-        Runs the entrie pipeline using the default settings. Check pydicer.pipeline for more info
+        Runs the entire pipeline using the default settings. Check pydicer.pipeline for more info
+
+            Example usage:
+                python -m pydicer.cli.run pipeline
+                or
+                python -m pydicer.cli.run pipeline --type e2e
+
         """
 
     return help_mesg

--- a/pydicer/cli/contants.py
+++ b/pydicer/cli/contants.py
@@ -1,41 +1,70 @@
-def get_sub_help_mesg(input_commands):
+def get_sub_help_mesg(input_commands, command):
     # pylint: disable=missing-function-docstring
+
     help_mesg = f"""Subcommand of the following: {input_commands}
 
+        test WORKING_DIRECTORY_PATH
 
-    test WORKING_DIRECTORY_PATH
-        - WORKING_DIRECTORY_PATH (str, optional): The working directory in which to
-    store the data fetched. Defaults to a temp directory.
-    
-        Example usage:
-            python -m pydicer.cli.run input --type test cli_test
-    
+        Runs the command using the default test data. Check pydicer.input.test for more info
 
-    pacs HOST_IP PORT AE_TITLE WORKING_DIRECTORY_PATH MODALITY [PATIENT_IDs]
-        - HOST_IP (str, optional): The IP address of host name of DICOM PACS. Defaults to 
-    'www.dicomserver.co.uk'.
-        - PORT (int, optional): The port to use to communicate on. Defaults to 11112.
-        - AE_TITLE (str, optional): AE Title to provide the DICOM service. Defaults to 
-    None.
-        - WORKING_DIRECTORY_PATH (str, optional): The working directory in which to
-    store the data fetched. Defaults to a temp directory.
-        - MODALITY (str, optional): The modality to retrieve DICOMs for. Defaults 
-    to 'GM'.
-        - PATIENT_IDs (str, required): a string-list of patient IDs (IDs seperated by spaces)
-     to retrieve the DICOMs for.
-    
-        Example usage:
-            python -m pydicer.cli.run input --type pacs www.dicomserver.co.uk 11112 DCMQUERY 
-    cli_test GM PAT004 PAT005
-    
-    
-    web DATA_URL WORKING_DIRECTORY_PATH
-       - DATA_URL (str): URL of the dataset to be downloaded from the internet
-       - WORKING_DIRECTORY_PATH (str, optional): The working directory in which to 
-    store the data fetched. Defaults to a temp directory.
-    
-        Example usage:
-            python -m pydicer.cli.run input --type web 
-https://zenodo.org/record/5276878/files/HNSCC.zip cli_test"""
+            - WORKING_DIRECTORY_PATH (str): The working directory in which to
+                store the data fetched. Defaults to a temp directory.
+        
+            Example usage:
+                python -m pydicer.cli.run input --type test cli_test
+
+        pacs WORKING_DIRECTORY_PATH HOST_IP PORT AE_TITLE MODALITY [PATIENT_IDs]
+
+        Runs the command by querying a DIOCM PACS server and storing the data on locally on the
+        filesystem
+
+            - WORKING_DIRECTORY_PATH (str): The working directory in which to
+                store the data fetched. Defaults to a temp directory.
+            - HOST_IP (str, optional): The IP address of host name of DICOM PACS. Defaults to 
+                'www.dicomserver.co.uk'.
+            - PORT (int, optional): The port to use to communicate on. Defaults to 11112.
+            - AE_TITLE (str, optional): AE Title to provide the DICOM service. Defaults to 
+            None.
+            - MODALITY (str, optional): The modality to retrieve DICOMs for. Defaults 
+                to 'GM'.
+            - PATIENT_IDs (str, required): a string-list of patient IDs (IDs seperated by spaces)
+                to retrieve the DICOMs for.
+        
+            Example usage:
+                python -m pydicer.cli.run input --type pacs www.dicomserver.co.uk 11112 DCMQUERY 
+                    cli_test GM PAT004 PAT005
+        
+        
+        web WORKING_DIRECTORY_PATH DATA_URL
+
+        Runs the command by downloading data from a provided URL and sotring it locally on the
+        filesystem
+
+        - WORKING_DIRECTORY_PATH (str): The working directory in which to 
+                store the data fetched. Defaults to a temp directory.
+        - DATA_URL (str): URL of the dataset to be downloaded from the internet
+        
+            Example usage:
+                python -m pydicer.cli.run input --type web 
+                https://zenodo.org/record/5276878/files/HNSCC.zip cli_test
+        """
+    if command == "pipeline":
+        help_mesg += """
+
+        filesystem WORKING_DIRECTORY_PATH
+
+        Runs the pipeline using a filesystem working directory which contains DICOM images
+
+            - WORKING_DIRECTORY_PATH (str): The working directory in which to
+                store the data fetched. Defaults to a temp directory.
+        
+            Example usage:
+                python -m pydicer.cli.run filesystem --type test cli_test
+        
+
+        e2e
+
+        Runs the entrie pipeline using the default settings. Check pydicer.pipeline for more info
+        """
 
     return help_mesg

--- a/pydicer/cli/input.py
+++ b/pydicer/cli/input.py
@@ -1,0 +1,8 @@
+import logging
+from pydicer.input.test import TestInput
+
+
+def testinput_cli(logger):
+    print("Running Test Input Module")
+    test_input = TestInput()
+    test_input.fetch_data()

--- a/pydicer/cli/input.py
+++ b/pydicer/cli/input.py
@@ -1,8 +1,9 @@
-import logging
 from pydicer.input.test import TestInput
 
 
-def testinput_cli(logger):
+def testinput_cli():
+    """Trigger the test input as a mini pipilien for the CLI tool
+    """
     print("Running Test Input Module")
     test_input = TestInput()
     test_input.fetch_data()

--- a/pydicer/cli/input.py
+++ b/pydicer/cli/input.py
@@ -6,13 +6,13 @@ from pydicer.input.pacs import DICOMPACSInput
 from pydicer.input.test import TestInput
 from pydicer.input.web import WebInput
 from pydicer.input.filesystem import FileSystemInput
-from pydicer.pipeline import run
 from pydicer.preprocess.data import PreprocessData
 from pydicer.convert.data import ConvertData
 from pydicer.visualise.data import VisualiseData
 
 
 logger = logging.getLogger(__name__)
+
 
 def run_pipeline(input_method, *args):
     """Run the pipeline using a specific input methodthe test data provided
@@ -57,6 +57,7 @@ def run_pipeline(input_method, *args):
     logger.info("Running Pipeline visualisation")
     visualise_data = VisualiseData(output_dir)
     visualise_data.visualise()
+
 
 def testinput_cli(working_dir):
     """Trigger the test input as a mini pipeline for the CLI tool

--- a/pydicer/cli/input.py
+++ b/pydicer/cli/input.py
@@ -1,11 +1,12 @@
 import sys
 
-from pydicer.input.test import TestInput
 from pydicer.input.pacs import DICOMPACSInput
+from pydicer.input.test import TestInput
+from pydicer.input.web import WebInput
 
 
 def testinput_cli(working_dir=None):
-    """Trigger the test input as a mini pipiline for the CLI tool
+    """Trigger the test input as a mini pipeline for the CLI tool
 
     Args:
         working_dir (str|pathlib.Path, optional): The working directory in which to
@@ -16,10 +17,6 @@ def testinput_cli(working_dir=None):
     test_input.fetch_data()
 
 
-def filesystem_cli():
-    pass
-
-
 def pacs_cli(
     host="www.dicomserver.co.uk",
     port=11112,
@@ -28,7 +25,7 @@ def pacs_cli(
     modalities="GM",
     *patients
 ):
-    """Trigger the DICOM PACS input as a mini pipiline for the CLI tool. If no inputs received,
+    """Trigger the DICOM PACS input as a mini pipeline for the CLI tool. If no inputs received,
     then by default it will retrieve some test data
 
     Example usage:
@@ -41,10 +38,10 @@ def pacs_cli(
         port (int, optional): The port to use to communicate on. Defaults to 11112.
         ae_title (str, optional): AE Title to provide the DICOM service. Defaults to None.
         working_dir (str|pathlib.Path, optional): The working directory in which to
-            store the data fetched. Defaults to a temp directory. Defaults to None.
+            store the data fetched. Defaults to a temp directory.
         modalities (str, optional): The modalities to retrieve DICOMs for. Defaults to "GM".
-        patients (str, required): a string-list of patient IDs (separated with spaces between each
-        element) to retrieve the DICOMs for.
+        patients (str, required): a string-list of patient IDs (IDs seperated by spaces) to
+            retrieve the DICOMs for.
     """
     if not patients:
         print(
@@ -58,8 +55,23 @@ def pacs_cli(
 
 
 def tcia_cli():
-    pass
+    """Trigger the TCIA input as a mini pipeline for the CLI tool."""
+    return
 
 
-def web_cli():
-    pass
+def web_cli(data_url, working_dir=None):
+    """Trigger the web input as a mini pipeline for the CLI tool.
+
+    Example usage:
+        python -m pydicer.cli.run input --type web
+            https://zenodo.org/record/5276878/files/HNSCC.zip ./cli_test
+
+    Args:
+        data_url (str): URL of the dataset to be downloaded from the internet
+        working_dir (str|pathlib.Path, optional): The working directory in which to
+            store the data fetched. Defaults to a temp directory.
+    """
+
+    print("Running web Input sub command")
+    web_input = WebInput(data_url, working_dir)
+    web_input.fetch_data()

--- a/pydicer/cli/input.py
+++ b/pydicer/cli/input.py
@@ -1,9 +1,65 @@
+import sys
+
 from pydicer.input.test import TestInput
+from pydicer.input.pacs import DICOMPACSInput
 
 
-def testinput_cli():
-    """Trigger the test input as a mini pipilien for the CLI tool
+def testinput_cli(working_dir=None):
+    """Trigger the test input as a mini pipiline for the CLI tool
+
+    Args:
+        working_dir (str|pathlib.Path, optional): The working directory in which to
+        store the data fetched. Defaults to a temp directory.
     """
-    print("Running Test Input Module")
-    test_input = TestInput()
+    print("Running Test Input sub command")
+    test_input = TestInput(working_dir)
     test_input.fetch_data()
+
+
+def filesystem_cli():
+    pass
+
+
+def pacs_cli(
+    host="www.dicomserver.co.uk",
+    port=11112,
+    ae_title=None,
+    working_dir=None,
+    modalities="GM",
+    *patients
+):
+    """Trigger the DICOM PACS input as a mini pipiline for the CLI tool. If no inputs received,
+    then by default it will retrieve some test data
+
+    Example usage:
+        python -m pydicer.cli.run input --type pacs www.dicomserver.co.uk 11112 DCMQUERY
+            cli_test GM PAT004 PAT005
+
+    Args:
+        host (str, optional): The IP address of host name of DICOM PACS. Defaults to
+            "www.dicomserver.co.uk".
+        port (int, optional): The port to use to communicate on. Defaults to 11112.
+        ae_title (str, optional): AE Title to provide the DICOM service. Defaults to None.
+        working_dir (str|pathlib.Path, optional): The working directory in which to
+            store the data fetched. Defaults to a temp directory. Defaults to None.
+        modalities (str, optional): The modalities to retrieve DICOMs for. Defaults to "GM".
+        patients (str, required): a string-list of patient IDs (separated with spaces between each
+        element) to retrieve the DICOMs for.
+    """
+    if not patients:
+        print(
+            "No patient IDs provided, please provided a list-string separated by spaces of "
+            "patients IDs to query for "
+        )
+        sys.exit()
+    print("Running DICOM PACS Input sub command")
+    pacs_input = DICOMPACSInput(host, int(port), ae_title, working_dir)
+    pacs_input.fetch_data(patients, [modalities])
+
+
+def tcia_cli():
+    pass
+
+
+def web_cli():
+    pass

--- a/pydicer/cli/input.py
+++ b/pydicer/cli/input.py
@@ -1,27 +1,86 @@
+import logging
 import sys
+from pathlib import Path
 
 from pydicer.input.pacs import DICOMPACSInput
 from pydicer.input.test import TestInput
 from pydicer.input.web import WebInput
+from pydicer.input.filesystem import FileSystemInput
+from pydicer.pipeline import run
+from pydicer.preprocess.data import PreprocessData
+from pydicer.convert.data import ConvertData
+from pydicer.visualise.data import VisualiseData
 
 
-def testinput_cli(working_dir=None):
+logger = logging.getLogger(__name__)
+
+def run_pipeline(input_method, *args):
+    """Run the pipeline using a specific input methodthe test data provided
+
+    Args:
+        working_dir (str, optional): Path to store test data.
+        input_method (str): the input method chosen to run this pipeline
+    """
+
+    logging.basicConfig(format="%(name)s\t%(levelname)s\t%(message)s", level=logging.DEBUG)
+
+    logger.info("Running Pipeline with Test Input")
+    print(args[0])
+    directory = Path(args[0])
+    directory.mkdir(exist_ok=True, parents=True)
+
+    working_dir = directory.joinpath("working")
+    working_dir.mkdir(exist_ok=True, parents=True)
+    output_dir = directory.joinpath("output")
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    if input_method == "test":
+        input_obj = testinput_cli(*args)
+    if input_method == "web":
+        input_obj = web_cli(*args)
+    elif input_method == "pacs":
+        input_obj = pacs_cli(*args)
+    else:
+        input_obj = FileSystemInput(*args)
+
+    # Preprocess the data fetch to prepare it for conversion
+    logger.info("Running Pipeline preprocessing")
+    preprocessed_data = PreprocessData(input_obj.working_directory, output_dir)
+    preprocessed_result = preprocessed_data.preprocess()
+
+    # Convert the data into the output directory
+    logger.info("Running Pipeline conversion")
+    convert_data = ConvertData(preprocessed_result, output_directory=output_dir)
+    convert_data.convert()
+
+    # TODO Visualise the converted data
+    logger.info("Running Pipeline visualisation")
+    visualise_data = VisualiseData(output_dir)
+    visualise_data.visualise()
+
+def testinput_cli(working_dir):
     """Trigger the test input as a mini pipeline for the CLI tool
+
+    Example usage:
+        python -m pydicer.cli.run input --type test ./cli_test
 
     Args:
         working_dir (str|pathlib.Path, optional): The working directory in which to
-        store the data fetched. Defaults to a temp directory.
+        store the data fetched.
     """
-    print("Running Test Input sub command")
+    logging.basicConfig(format="%(name)s\t%(levelname)s\t%(message)s", level=logging.DEBUG)
+
+    logger.info("Running Test Input sub command")
     test_input = TestInput(working_dir)
     test_input.fetch_data()
+    return test_input
 
 
 def pacs_cli(
+    working_dir,
     host="www.dicomserver.co.uk",
     port=11112,
     ae_title=None,
-    working_dir=None,
     modalities="GM",
     *patients
 ):
@@ -29,29 +88,30 @@ def pacs_cli(
     then by default it will retrieve some test data
 
     Example usage:
-        python -m pydicer.cli.run input --type pacs www.dicomserver.co.uk 11112 DCMQUERY
-            cli_test GM PAT004 PAT005
+        python -m pydicer.cli.run input --type pacs ./cli_test www.dicomserver.co.uk 11112 DCMQUERY
+            GM PAT004 PAT005
 
     Args:
+        working_dir (str|pathlib.Path, optional): The working directory in which to
+            store the data fetched.
         host (str, optional): The IP address of host name of DICOM PACS. Defaults to
             "www.dicomserver.co.uk".
         port (int, optional): The port to use to communicate on. Defaults to 11112.
         ae_title (str, optional): AE Title to provide the DICOM service. Defaults to None.
-        working_dir (str|pathlib.Path, optional): The working directory in which to
-            store the data fetched. Defaults to a temp directory.
         modalities (str, optional): The modalities to retrieve DICOMs for. Defaults to "GM".
         patients (str, required): a string-list of patient IDs (IDs seperated by spaces) to
             retrieve the DICOMs for.
     """
     if not patients:
-        print(
+        logger.error(
             "No patient IDs provided, please provided a list-string separated by spaces of "
             "patients IDs to query for "
         )
         sys.exit()
-    print("Running DICOM PACS Input sub command")
+    logger.info("Running DICOM PACS Input sub command")
     pacs_input = DICOMPACSInput(host, int(port), ae_title, working_dir)
     pacs_input.fetch_data(patients, [modalities])
+    return pacs_input
 
 
 def tcia_cli():
@@ -59,19 +119,20 @@ def tcia_cli():
     return
 
 
-def web_cli(data_url, working_dir=None):
+def web_cli(working_dir, data_url):
     """Trigger the web input as a mini pipeline for the CLI tool.
 
     Example usage:
-        python -m pydicer.cli.run input --type web
-            https://zenodo.org/record/5276878/files/HNSCC.zip ./cli_test
+        python -m pydicer.cli.run input --type web ./cli_test
+            https://zenodo.org/record/5276878/files/HNSCC.zip
 
     Args:
+        working_dir (str|pathlib.Path): The working directory in which to
+            store the data fetched.
         data_url (str): URL of the dataset to be downloaded from the internet
-        working_dir (str|pathlib.Path, optional): The working directory in which to
-            store the data fetched. Defaults to a temp directory.
     """
 
-    print("Running web Input sub command")
+    logger.info("Running web Input sub command")
     web_input = WebInput(data_url, working_dir)
     web_input.fetch_data()
+    return web_input

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -1,0 +1,66 @@
+import argparse
+import sys
+
+from pydicer.cli.input import testinput_cli
+from pydicer.pipeline import run_test
+
+
+def parse_sub_command(desc, tools, default_choice):
+    """Generic function to take in dynamic input and trigger the respective sub commands
+
+    Args:
+        desc (str): help description of what the sub command does
+        tools (dict): dictionary of which sub command type can be run
+        default_choice (str): default sub command type that will be run in the case no input is
+        received from the user
+    """
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument(
+        "--type",
+        help=f"Subcommand of the following: {str(list(tools.keys())).replace(', ', '|')}",
+        default=tools[default_choice],
+        choices=tools,
+        nargs=2,
+    )
+    args = parser.parse_args(sys.argv[2:])
+    args.type()
+
+
+def parse_sub_input():
+    """function to parse the input command args"""
+    parse_sub_command(
+        "Run the Input module only",
+        INPUT_TOOLS,
+        "test",
+    )
+
+
+# Commands that can be run
+MODULES = {"pipeline": run_test, "input": parse_sub_input}
+# Sub command types for the Input command
+INPUT_TOOLS = {"test": testinput_cli}
+
+
+def pydicer_cli():
+    """
+    Trigger pydicer CLI
+    """
+
+    commands = str(list(MODULES.keys())).replace(", ", "|")
+
+    parser = argparse.ArgumentParser(
+        description="pydicer CLI (Command Line Interface)",
+        usage=f"python -m pydicer.cli.run {commands}",
+    )
+
+    parser.add_argument(
+        "command",
+        help=f"One of the following commands: {commands}",
+    )
+
+    args = parser.parse_args(sys.argv[1:2])
+    MODULES[args.command]()
+
+
+if __name__ == "__main__":
+    pydicer_cli()

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -1,8 +1,18 @@
 import argparse
+from argparse import RawTextHelpFormatter
 import sys
 
-from pydicer.cli.input import testinput_cli, filesystem_cli, pacs_cli, tcia_cli, web_cli
+from pydicer.cli.contants import get_sub_help_mesg
 from pydicer.pipeline import run_test
+from pydicer.cli.input import testinput_cli, pacs_cli, tcia_cli, web_cli
+
+# Sub command types for the Input command
+INPUT_TOOLS = {
+    "test": testinput_cli,
+    "pacs": pacs_cli,
+    "tcia": tcia_cli,
+    "web": web_cli,
+}
 
 
 def parse_sub_input():
@@ -14,18 +24,8 @@ def parse_sub_input():
     )
 
 
-# Commands that can be run
+INPUT_COMMANDS = str(list(INPUT_TOOLS.keys())).replace(", ", "|")
 MODULES = {"pipeline": run_test, "input": parse_sub_input}
-
-# Sub command types for the Input command
-INPUT_TOOLS = {
-    "test": testinput_cli,
-    "filesystem": filesystem_cli,
-    "pacs": pacs_cli,
-    "tcia": tcia_cli,
-    "web": web_cli,
-}
-
 COMMANDS = str(list(MODULES.keys())).replace(", ", "|")
 
 
@@ -38,10 +38,10 @@ def parse_sub_command(desc, tools, default_choice):
         default_choice (str): default sub command type that will be run in the case no input is
         received from the user
     """
-    parser = argparse.ArgumentParser(description=desc)
+    parser = argparse.ArgumentParser(description=desc, formatter_class=RawTextHelpFormatter)
     parser.add_argument(
         "--type",
-        help=f"Subcommand of the following: {COMMANDS}",
+        help=get_sub_help_mesg(INPUT_COMMANDS),
         default=default_choice,
         choices=tools,
     )

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -53,6 +53,7 @@ def pydicer_cli():
         usage=f"python -m pydicer.cli.run {commands}",
     )
 
+    # Default to "pipeline" option without input
     parser.add_argument(
         "command",
         help=f"One of the following commands: {commands}",

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -1,3 +1,16 @@
+"""
+Command Line Interface tool to run pydicer pipeline or specific modules on their own
+
+usage: python -m pydicer.cli.run ['pipeline'|'input']
+
+pydicer CLI (Command Line Interface)
+
+positional arguments:
+  command     One of the following COMMANDS: ['pipeline'|'input']
+
+optional arguments:
+  -h, --help  show help message 
+"""
 import argparse
 from argparse import RawTextHelpFormatter
 import sys

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -9,7 +9,7 @@ positional arguments:
   command     One of the following COMMANDS: ['pipeline'|'input']
 
 optional arguments:
-  -h, --help  show help message 
+  -h, --help  show help message
 """
 import argparse
 from argparse import RawTextHelpFormatter

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -26,13 +26,8 @@ PIPELINE_TOOLS = {
 
 def parse_sub_input(command):
     """function to parse the input command args"""
-    parse_sub_command(
-        command,
-        "Run the Input module only",
-        INPUT_TOOLS,
-        "test",
-        INPUT_COMMANDS
-    )
+    parse_sub_command(command, "Run the Input module only", INPUT_TOOLS, "test", INPUT_COMMANDS)
+
 
 def parse_sub_pipeline(command):
     """function to parse the pipeline command args"""
@@ -41,8 +36,9 @@ def parse_sub_pipeline(command):
         "Run the pipeline with a specific input method",
         PIPELINE_TOOLS,
         "e2e",
-        PIPELINE_COMMANDS
+        PIPELINE_COMMANDS,
     )
+
 
 INPUT_COMMANDS = str(list(INPUT_TOOLS.keys())).replace(", ", "|")
 PIPELINE_COMMANDS = str(list(PIPELINE_TOOLS.keys())).replace(", ", "|")

--- a/pydicer/cli/run.py
+++ b/pydicer/cli/run.py
@@ -1,8 +1,32 @@
 import argparse
 import sys
 
-from pydicer.cli.input import testinput_cli
+from pydicer.cli.input import testinput_cli, filesystem_cli, pacs_cli, tcia_cli, web_cli
 from pydicer.pipeline import run_test
+
+
+def parse_sub_input():
+    """function to parse the input command args"""
+    parse_sub_command(
+        "Run the Input module only",
+        INPUT_TOOLS,
+        "test",
+    )
+
+
+# Commands that can be run
+MODULES = {"pipeline": run_test, "input": parse_sub_input}
+
+# Sub command types for the Input command
+INPUT_TOOLS = {
+    "test": testinput_cli,
+    "filesystem": filesystem_cli,
+    "pacs": pacs_cli,
+    "tcia": tcia_cli,
+    "web": web_cli,
+}
+
+COMMANDS = str(list(MODULES.keys())).replace(", ", "|")
 
 
 def parse_sub_command(desc, tools, default_choice):
@@ -17,28 +41,13 @@ def parse_sub_command(desc, tools, default_choice):
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument(
         "--type",
-        help=f"Subcommand of the following: {str(list(tools.keys())).replace(', ', '|')}",
-        default=tools[default_choice],
+        help=f"Subcommand of the following: {COMMANDS}",
+        default=default_choice,
         choices=tools,
-        nargs=2,
-    )
-    args = parser.parse_args(sys.argv[2:])
-    args.type()
-
-
-def parse_sub_input():
-    """function to parse the input command args"""
-    parse_sub_command(
-        "Run the Input module only",
-        INPUT_TOOLS,
-        "test",
     )
 
-
-# Commands that can be run
-MODULES = {"pipeline": run_test, "input": parse_sub_input}
-# Sub command types for the Input command
-INPUT_TOOLS = {"test": testinput_cli}
+    args = parser.parse_args(sys.argv[2:4])
+    tools[args.type](*sys.argv[4:])
 
 
 def pydicer_cli():
@@ -46,17 +55,15 @@ def pydicer_cli():
     Trigger pydicer CLI
     """
 
-    commands = str(list(MODULES.keys())).replace(", ", "|")
-
     parser = argparse.ArgumentParser(
         description="pydicer CLI (Command Line Interface)",
-        usage=f"python -m pydicer.cli.run {commands}",
+        usage=f"python -m pydicer.cli.run {COMMANDS}",
     )
 
     # Default to "pipeline" option without input
     parser.add_argument(
         "command",
-        help=f"One of the following commands: {commands}",
+        help=f"One of the following COMMANDS: {COMMANDS}",
     )
 
     args = parser.parse_args(sys.argv[1:2])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydicom >= 2.1.2
 SimpleITK >= 2.0.2
 platipy >= 0.1.3
 pyorthanc >= 0.2.14
+argparse >=  1.4.0


### PR DESCRIPTION
Hey @pchlap, made the first version of what a CLI tool for pydicer might be. Currently, it can run 2 commands; the pipeline as a whole, and the input module alone.

We have the potential for input for the user to select which input method they want (for now only the 'testinput' method has been implemented). For the other modules, it could be useful to have them run separately and in the case of debugging, you could run modules singularly and export their output into files when you run the CLI.  So potentially, if it is meaningful to get other modules to be run on the CLI, we can build in the other modules easily using this structure.

Open to ideas and other design approaches to this, cheers! :)