### PR TITLE
convert.data quarantine check

### DIFF
--- a/pydicer/preprocess/data.py
+++ b/pydicer/preprocess/data.py
@@ -146,8 +146,6 @@ class PreprocessData:
                 )
                 copy_file_to_quarantine(file, self.output_directory, e)
 
-                # TODO Send to quarantine
-
         # Sort the the DataFrame by the patient then series uid and the slice location, ensuring
         # that the slices are ordered correctly
         df = df.sort_values(["patient_id", "series_uid", "slice_location"])


### PR DESCRIPTION
Hey @rnfinnegan @pchlap, just a quick addition to move an entire series' DICOMs to quarantine in case we can't convert it to nifti. The reason I move the entire series is because we grab all DICOMs at once and convert, so there is no way of telling which slice (if any) might have caused this error. We could potentially report it as an error to log rather than sending all DICOMs to quarantine. Open to other suggestions, cheers!