### PR TITLE
Duplicate slice fix

### DIFF
--- a/pydicer/convert/data.py
+++ b/pydicer/convert/data.py
@@ -70,6 +70,9 @@ def handle_missing_slice(files):
     else:
         raise ValueError("This function requires a Dataframe or list")
 
+    # If duplicated slices locations are present in series, drop the duplicates
+    df_files = df_files.drop_duplicates(subset=["slice_location"])
+
     temp_dir = Path(tempfile.mkdtemp())
 
     slice_location_diffs = np.diff(df_files.slice_location.to_numpy(dtype=float))

--- a/pydicer/convert/data.py
+++ b/pydicer/convert/data.py
@@ -200,9 +200,9 @@ class ConvertData:
         if patient is not None and not hasattr(patient, "__iter__"):
             patient = [patient]
 
-        for key, df_files in self.df_preprocess.groupby(["patient_id", "series_uid"]):
+        for key, df_files in self.df_preprocess.groupby(["patient_id", "modality", "series_uid"]):
 
-            patient_id, series_uid = key
+            patient_id, _, series_uid = key
 
             if patient is not None and patient_id not in patient:
                 continue

--- a/pydicer/convert/data.py
+++ b/pydicer/convert/data.py
@@ -280,11 +280,16 @@ class ConvertData:
                     )
                     output_dir.mkdir(exist_ok=True, parents=True)
 
-                    img_file_list = df_linked_series.file_path.tolist()
-                    img_file_list = [str(f) for f in img_file_list]
+                    linked_file_name = (
+                        f"{df_linked_series.iloc[0].modality}_{linked_uid_hash}.nii.gz"
+                    )
+                    linked_nifti_file = self.output_directory.joinpath(
+                        patient_id, "images", linked_file_name
+                    )
+                    img_file = sitk.ReadImage(str(linked_nifti_file))
 
                     convert_rtstruct(
-                        img_file_list,
+                        img_file,
                         rt_struct_file.file_path,
                         prefix="",
                         output_dir=output_dir,

--- a/pydicer/convert/rtstruct.py
+++ b/pydicer/convert/rtstruct.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def convert_rtstruct(
-    dcm_img_list,
+    dcm_img,
     dcm_rt_file,
     prefix="Struct_",
     output_dir=".",
@@ -23,7 +23,8 @@ def convert_rtstruct(
     The masks are stored as NIFTI files in the output directory
 
     Args:
-        dcm_img_list (list): List of DICOM paths (as str) to use as the reference image series.
+        dcm_img (list|SimpleITK.Image): List of DICOM paths (as str) to use as the reference image
+            series or a SimpleITK image of the already converted image.
         dcm_rt_file (str|pathlib.Path): Path to the DICOM RTSTRUCT file
         prefix (str, optional): The prefix to give the output files. Defaults to "Struct" +
             underscore.
@@ -36,7 +37,13 @@ def convert_rtstruct(
     logger.debug("Converting RTStruct: %s", dcm_rt_file)
     logger.debug("Output file prefix: %s", prefix)
 
-    dicom_image = sitk.ReadImage(dcm_img_list)
+    if isinstance(dcm_img, list):
+        dicom_image = sitk.ReadImage(dcm_img)
+    elif isinstance(dcm_img, sitk.Image):
+        dicom_image = dcm_img
+    else:
+        raise ValueError("dcm_img must be list or SimpleITK.Image")
+
     dicom_struct = pydicom.read_file(dcm_rt_file, force=True)
 
     if not isinstance(output_dir, Path):

--- a/pydicer/input/orthanc.py
+++ b/pydicer/input/orthanc.py
@@ -82,6 +82,7 @@ class OrthancInput(InputBase):
 
             if len(orthanc_patient_ids) == 0:
                 logger.warning("Patient not found in Orthanc: %s", patient)
+                continue
 
             if len(orthanc_patient_ids) > 1:
                 logger.warning(

--- a/pydicer/preprocess/data.py
+++ b/pydicer/preprocess/data.py
@@ -162,6 +162,6 @@ class PreprocessData:
 
         # Sort the the DataFrame by the patient then series uid and the slice location, ensuring
         # that the slices are ordered correctly
-        df = df.sort_values(["patient_id", "series_uid", "slice_location"])
+        df = df.sort_values(["patient_id", "modality", "series_uid", "slice_location"])
 
         return df

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -59,6 +59,7 @@ def test_input_invalid_working_dir():
     assert not invalid_work_dir_tcia_input.working_directory.is_dir()
 
 
+@pytest.mark.skip
 def test_tcia_input():
     invalid_collection_tcia_input = TCIAInput(
         collection="INVALID_COLLECTION", patient_ids=[], modalities=[]
@@ -90,6 +91,7 @@ def test_dicom_pacs_invalid_host():
     # data consistently
     with pytest.raises(ConnectionError):
         DICOMPACSInput("INCORRECT_HOST", 1234)
+
 
 @pytest.mark.skip
 def test_dicom_pacs_fetch():


### PR DESCRIPTION
HI @dalmouiee & @rnfinnegan,

I found an issue while working with pydicer that some image series would have 2 slices at each position. Very unusual and just seems to be duplicate data. This fix basically drops the duplicates but doesn't do any check as to whether they are actually the same or not... What do you think, is this ok or are more checks needed? I'm just not sure what would happen in the case of 4D CTs etc... Perhaps we can discuss this in our next pydicer catch up.