### PR TITLE
force flag for preprocess step

### DIFF
--- a/pydicer/tool.py
+++ b/pydicer/tool.py
@@ -78,13 +78,8 @@ class PyDicer:
         if len(self.dicom_directories) == 0:
             raise ValueError("No DICOM input locations set. Add one using the add_input function.")
 
-        if self.pydicer_directory.joinpath("preprocessed.csv").exists() and not force:
-            logger.debug("Data already preprocessed")
-            self.preprocessed_data = read_preprocessed_data(self.working_directory)
-            return
-
         pd = PreprocessData(self.working_directory)
-        pd.preprocess(self.dicom_directories)
+        pd.preprocess(self.dicom_directories, force=force)
 
         self.preprocessed_data = read_preprocessed_data(self.working_directory)
 


### PR DESCRIPTION
Hi @dalmouiee, I just thought of a way to make the preprocess step more efficient (in cases where data is being preocesed in batches).

Other steps (eg convert, visualise) already have a `force` flag. When true the data will be processed no matter what. If false it will only be converted/visualised if it hasn't already been (output file doesn't exist).

So this PR adds in a `force` flag for the preprocess step too. When set to false, files are only scanned in that step if they haven't already been. This should make the scenario where you're pull DICOM in batches more effificient to preprocess.
What do you think?

(Note that the PyDicer preprocess function already had a `force` flag. But that was to only either preprocess all the data or not. With this new change it will actually manage this file by file which should make it much more useful).