### PR TITLE
Fill nan values when loading multiple DVHs

### DIFF
--- a/pydicer/analyse/data.py
+++ b/pydicer/analyse/data.py
@@ -201,6 +201,8 @@ class AnalyseData:
         df = pd.concat(dfs)
         df.sort_values(["patient", "struct_hash", "dose_hash", "label"], inplace=True)
         df.reset_index(inplace=True, drop=True)
+        # Fill NaN with zeros since these can appear after concat
+        df.fillna(0, inplace=True)
 
         return df
 


### PR DESCRIPTION
Hi @dalmouiee, just a small bug fix here to avoid NaN values when concatenating differently binned DVHs which was leading to some NaN dose metrics being computed. A review would be appreciated :) Thanks!