### PR TITLE
add_norm_fix_resampling_addtoOutput

### DIFF
--- a/pydicer/analyse/data.py
+++ b/pydicer/analyse/data.py
@@ -448,10 +448,10 @@ class AnalyseData:
                             continue
 
                     # Add normalisation of image after resampling
-                    normalizeImage = settings.get("normalizeImage")
-                    normalizeScale = settings.get("normalizeScale")
+                    normalize_image = settings.get("normalizeImage")
+                    normalize_scale = settings.get("normalizeScale")
 
-                    if normalizeImage is not False and normalizeScale is not None:
+                    if normalize_image is not False and normalize_scale is not None:
                         try:
                             image = imageoperations.normalizeImage(image, **settings)
                         except ValueError as e:
@@ -524,13 +524,22 @@ class AnalyseData:
                         meta_data_cols.append(col_key)
 
                 #add normalisation and resampling details
-
-                output_frame.insert(loc=0, column="NormalisationScale", value=settings["normalizeScale"])
-                
+                output_frame.insert(
+                    loc=0, 
+                    column="NormalisationScale", 
+                    value=settings["normalizeScale"]
+                )
                 if settings["resampledPixelSpacing"] is not None:
-                    output_frame.insert(loc=0, column="ResampledPixelSpacing", value=settings["resampledPixelSpacing"][0])
+                    output_frame.insert(
+                        loc=0, 
+                        column="ResampledPixelSpacing", 
+                        value=settings["resampledPixelSpacing"][0]
+                )
                 else:
-                    output_frame.insert(loc=0, column="ResampledPixelSpacing", value=settings["resampledPixelSpacing"])
+                    output_frame.insert(
+                        loc=0, column="ResampledPixelSpacing", 
+                        value=settings["resampledPixelSpacing"]
+                )
 
                 output_frame.insert(loc=0, column="StructHashedUID", value=struct_row.hashed_uid)
                 output_frame.insert(loc=0, column="ImageHashedUID", value=img_row.hashed_uid)

--- a/pydicer/analyse/data.py
+++ b/pydicer/analyse/data.py
@@ -525,21 +525,18 @@ class AnalyseData:
 
                 #add normalisation and resampling details
                 output_frame.insert(
-                    loc=0, 
-                    column="NormalisationScale", 
-                    value=settings["normalizeScale"]
+                    loc=0, column="NormalisationScale", value=settings["normalizeScale"]
                 )
                 if settings["resampledPixelSpacing"] is not None:
                     output_frame.insert(
-                        loc=0, 
-                        column="ResampledPixelSpacing", 
+                        loc=0,column="ResampledPixelSpacing",
                         value=settings["resampledPixelSpacing"][0]
-                )
+                    )
                 else:
                     output_frame.insert(
-                        loc=0, column="ResampledPixelSpacing", 
+                        loc=0, column="ResampledPixelSpacing",
                         value=settings["resampledPixelSpacing"]
-                )
+                    )
 
                 output_frame.insert(loc=0, column="StructHashedUID", value=struct_row.hashed_uid)
                 output_frame.insert(loc=0, column="ImageHashedUID", value=img_row.hashed_uid)

--- a/pydicer/analyse/data.py
+++ b/pydicer/analyse/data.py
@@ -62,6 +62,8 @@ PYRAD_DEFAULT_SETTINGS = {
     "interpolator": "sitkNearestNeighbor",
     "verbose": True,
     "removeOutliers": 10000,
+    "normalizeImage": False,
+    "normalizeScale": None,
 }
 
 
@@ -433,9 +435,6 @@ class AnalyseData:
                     interpolator = settings.get("interpolator")
                     resample_pixel_spacing = settings.get("resampledPixelSpacing")
 
-                    resample_pixel_spacing = list(image.GetSpacing())
-                    settings["resampledPixelSpacing"] = resample_pixel_spacing
-
                     if resample_to_image:
                         resample_pixel_spacing = list(image.GetSpacing())
                         settings["resampledPixelSpacing"] = resample_pixel_spacing
@@ -446,6 +445,18 @@ class AnalyseData:
                         except ValueError as e:
                             logger.exception(e)
                             logger.error("Error during resampling")
+                            continue
+
+                    # Add normalisation of image after resampling
+                    normalizeImage = settings.get("normalizeImage")
+                    normalizeScale = settings.get("normalizeScale")
+
+                    if normalizeImage is not False and normalizeScale is not None:
+                        try:
+                            image = imageoperations.normalizeImage(image, **settings)
+                        except ValueError as e:
+                            logger.exception(e)
+                            logger.error("Error during nomalisation")
                             continue
 
                     df_contour = pd.DataFrame()
@@ -511,6 +522,15 @@ class AnalyseData:
 
                     if col_key not in meta_data_cols:
                         meta_data_cols.append(col_key)
+
+                #add normalisation and resampling details
+
+                output_frame.insert(loc=0, column="NormalisationScale", value=settings["normalizeScale"])
+                
+                if settings["resampledPixelSpacing"] is not None:
+                    output_frame.insert(loc=0, column="ResampledPixelSpacing", value=settings["resampledPixelSpacing"][0])
+                else:
+                    output_frame.insert(loc=0, column="ResampledPixelSpacing", value=settings["resampledPixelSpacing"])
 
                 output_frame.insert(loc=0, column="StructHashedUID", value=struct_row.hashed_uid)
                 output_frame.insert(loc=0, column="ImageHashedUID", value=img_row.hashed_uid)


### PR DESCRIPTION
Adding the normalisation function with PyRadiomics imageoperations, as well as fixing the issue of resampling referencing itself to get pixel spacing and therefore not completing resampling with desired pixel spacing. Also added lines to store info on resampling pixel spacing and normalisation in output file.