### PR TITLE
Visualise masks only ignoring other files

### DIFF
--- a/pydicer/visualise/data.py
+++ b/pydicer/visualise/data.py
@@ -204,7 +204,10 @@ class VisualiseData:
                         for f in struct_dir.glob("*.nii.gz")
                     }
 
-                    masks = {k: masks[k] for k in masks if masks[k].GetPixelID() in render_mask_types}
+                    masks = {
+                        k: masks[k] for k in masks
+                        if masks[k].GetPixelID() in render_mask_types
+                    }
 
                     if len(masks) == 0:
                         logger.warning(
@@ -283,7 +286,10 @@ class VisualiseData:
                             f.name.replace(".nii.gz", ""): sitk.ReadImage(str(f))
                             for f in struct_dir.glob("*.nii.gz")
                         }
-                        masks = {k: masks[k] for k in masks if masks[k].GetPixelID() in render_mask_types}
+                        masks = {
+                            k: masks[k] for k in masks
+                            if masks[k].GetPixelID() in render_mask_types
+                        }
 
                         if len(masks) == 0:
                             logger.warning(

--- a/pydicer/visualise/data.py
+++ b/pydicer/visualise/data.py
@@ -59,6 +59,7 @@ class VisualiseData:
         )
 
         visualise_modalities = ["CT", "MR", "RTSTRUCT", "RTDOSE", "PT"]
+        render_mask_types = [sitk.sitkUInt8, sitk.sitkUInt16, sitk.sitkUInt32, sitk.sitkUInt64]
         df_process = df_process[df_process.modality.isin(visualise_modalities)]
 
         for _, row in get_iterator(
@@ -203,6 +204,8 @@ class VisualiseData:
                         for f in struct_dir.glob("*.nii.gz")
                     }
 
+                    masks = {k: masks[k] for k in masks if masks[k].GetPixelID() in render_mask_types}
+
                     if len(masks) == 0:
                         logger.warning(
                             "No contours found in structure directory: %s", {struct_dir}
@@ -280,6 +283,7 @@ class VisualiseData:
                             f.name.replace(".nii.gz", ""): sitk.ReadImage(str(f))
                             for f in struct_dir.glob("*.nii.gz")
                         }
+                        masks = {k: masks[k] for k in masks if masks[k].GetPixelID() in render_mask_types}
 
                         if len(masks) == 0:
                             logger.warning(


### PR DESCRIPTION
This is just a small fix to filter out SimpleITK images which aren't masks before visualisation (I store other probability maps etc alongside mask files which can cause issues otherwise).